### PR TITLE
Fix calling the toString() method instead of build() of UserAgentBuilder

### DIFF
--- a/src/main/java/masecla/reddit4j/client/Reddit4J.java
+++ b/src/main/java/masecla/reddit4j/client/Reddit4J.java
@@ -267,7 +267,7 @@ public class Reddit4J {
     }
 
     public Reddit4J setUserAgent(UserAgentBuilder userAgent) {
-        this.userAgent = userAgent.toString();
+        this.userAgent = userAgent.build();
         return this;
     }
 


### PR DESCRIPTION
I've replaced this toString() call with build() so it works as intended. UserAgentBuilder doesn't override toString() so it would just return Object.toString() which isn't useful in this context.