### PR TITLE
Fix listings that were using the RedditThing id for the before and after methods, and instead use the fullname id

### DIFF
--- a/src/main/java/masecla/reddit4j/objects/RedditComment.java
+++ b/src/main/java/masecla/reddit4j/objects/RedditComment.java
@@ -6,7 +6,13 @@ import lombok.Data;
 import masecla.reddit4j.objects.adapters.RedditCommentRepliesAdapter;
 
 @Data
-public class RedditComment extends RedditThing {
+public class RedditComment extends RedditThing implements RedditNameable {
+
+    /**
+     * the fullname identifier of this comment
+     */
+    private String name;
+
     /**
      * who approved this comment. null if nobody or you are not a mod
      */

--- a/src/main/java/masecla/reddit4j/objects/RedditNameable.java
+++ b/src/main/java/masecla/reddit4j/objects/RedditNameable.java
@@ -1,0 +1,5 @@
+package masecla.reddit4j.objects;
+
+public interface RedditNameable {
+    String getName();
+}

--- a/src/main/java/masecla/reddit4j/objects/RedditPost.java
+++ b/src/main/java/masecla/reddit4j/objects/RedditPost.java
@@ -12,7 +12,7 @@ import java.util.List;
  * AKA t3
  */
 @Data
-public class RedditPost extends RedditThing implements RedditPostActions {
+public class RedditPost extends RedditThing implements RedditPostActions, RedditNameable {
 
     private Reddit4J client;
 

--- a/src/main/java/masecla/reddit4j/objects/RedditThing.java
+++ b/src/main/java/masecla/reddit4j/objects/RedditThing.java
@@ -14,7 +14,7 @@ package masecla.reddit4j.objects;
  *
  * @author Matt
  */
-public class RedditThing extends RedditObject {
+public abstract class RedditThing extends RedditObject {
 	private String id;
 
 	public void setId(String id) {

--- a/src/main/java/masecla/reddit4j/objects/RedditUser.java
+++ b/src/main/java/masecla/reddit4j/objects/RedditUser.java
@@ -3,7 +3,7 @@ package masecla.reddit4j.objects;
 import masecla.reddit4j.client.Reddit4J;
 import masecla.reddit4j.requests.SubredditPostListingEndpointRequest;
 
-public class RedditUser extends RedditThing implements RedditUserActions {
+public class RedditUser extends RedditThing implements RedditUserActions, RedditNameable {
 	private Reddit4J client;
 
 	private String name;

--- a/src/main/java/masecla/reddit4j/requests/AbstractListingEndpointRequest.java
+++ b/src/main/java/masecla/reddit4j/requests/AbstractListingEndpointRequest.java
@@ -6,13 +6,14 @@ import com.google.gson.JsonParser;
 import masecla.reddit4j.client.Reddit4J;
 import masecla.reddit4j.exceptions.AuthenticationException;
 import masecla.reddit4j.objects.RedditThing;
+import masecla.reddit4j.objects.RedditNameable;
 import org.jsoup.Connection;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class AbstractListingEndpointRequest<T extends RedditThing, S extends AbstractListingEndpointRequest<?, ?>> {
+public abstract class AbstractListingEndpointRequest<T extends RedditThing & RedditNameable, S extends AbstractListingEndpointRequest<?, ?>> {
     protected String endpointPath;
     protected Reddit4J client;
     protected final Class<T> clazz;
@@ -53,7 +54,7 @@ public abstract class AbstractListingEndpointRequest<T extends RedditThing, S ex
     }
 
     public S after(T after) {
-        this.after = (after == null) ? null : after.getId();
+        this.after = (after == null) ? null : after.getName();
         return self;
     }
 
@@ -63,7 +64,7 @@ public abstract class AbstractListingEndpointRequest<T extends RedditThing, S ex
     }
 
     public S before(T before) {
-        this.before = (before == null) ? null : before.getId();
+        this.before = (before == null) ? null : before.getName();
         return self;
     }
 


### PR DESCRIPTION
Fix listings that were using the RedditThing id for the before(T) and after(T) methods, and instead use the fullname id.
Issue was raised on the Discord by a user who was unable fetch the next page of Subreddit posts when using the after(T) method.