### PR TITLE
Add functionality to call /search API

### DIFF
--- a/src/main/java/masecla/reddit4j/client/Reddit4J.java
+++ b/src/main/java/masecla/reddit4j/client/Reddit4J.java
@@ -500,6 +500,11 @@ public class Reddit4J {
         return new RedditUserCommentListingEndpointRequest("/user/" + username + "/comments", this);
     }
 
+    public RedditSearchListingEndpointRequest getSearchResult(String subReddit) {
+        return new RedditSearchListingEndpointRequest("/r/" + subReddit + "/search", this);
+    }
+
+
     public String getRawJson(String endpointPath, Method method, boolean authorized) throws IOException, InterruptedException {
         Connection connection;
         if (authorized) {

--- a/src/main/java/masecla/reddit4j/client/Reddit4JBeta.java
+++ b/src/main/java/masecla/reddit4j/client/Reddit4JBeta.java
@@ -72,6 +72,8 @@ public class Reddit4JBeta {
 		result.add("/api/spoiler");
 		result.add("/api/unspoiler");
 
+		result.add("/search");
+
 		return result;
 	}
 

--- a/src/main/java/masecla/reddit4j/objects/Sorting.java
+++ b/src/main/java/masecla/reddit4j/objects/Sorting.java
@@ -5,7 +5,9 @@ public enum Sorting {
     NEW("new"),
     RISING("rising"),
     CONTROVERSIAL("controversial"),
-    TOP("top");
+    TOP("top"),
+    COMMENTS("comments"),
+    RELEVANCE("relevance");
 
     private final String value;
 

--- a/src/main/java/masecla/reddit4j/objects/Type.java
+++ b/src/main/java/masecla/reddit4j/objects/Type.java
@@ -1,0 +1,17 @@
+package masecla.reddit4j.objects;
+
+public enum Type {
+    SR("sr"),
+    LINK("link"),
+    USER("user");
+
+    private final String value;
+
+    Type(String value) {
+        this.value = value;
+    }
+    public String getValue() {
+        return value;
+    }
+}
+

--- a/src/main/java/masecla/reddit4j/objects/subreddit/RedditSearch.java
+++ b/src/main/java/masecla/reddit4j/objects/subreddit/RedditSearch.java
@@ -1,0 +1,331 @@
+package masecla.reddit4j.objects.subreddit;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import masecla.reddit4j.objects.RedditNameable;
+import masecla.reddit4j.objects.RedditThing;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+public class RedditSearch extends RedditThing implements RedditNameable {
+    @SerializedName("approved_at_utc")
+    private Object approvedAtUtc;
+    /**
+     * usually is a string, reporting the name of the subreddit but when type param is set to "user", this attribute is a complex object.
+     */
+    @SerializedName("subreddit")
+    private Object subreddit;
+
+    @SerializedName("selftext")
+    private String selftext;
+
+    @SerializedName("author_fullname")
+    private String authorFullname;
+
+    @SerializedName("saved")
+    private boolean saved;
+
+    @SerializedName("mod_reason_title")
+    private String modReasonTitle;
+
+    @SerializedName("gilded")
+    private int gilded;
+
+    @SerializedName("clicked")
+    private boolean clicked;
+
+    @SerializedName("title")
+    private String title;
+
+    @SerializedName("link_flair_richtext")
+    private List<Object> linkFlairRichtext;
+
+    @SerializedName("subreddit_name_prefixed")
+    private String subredditNamePrefixed;
+
+    @SerializedName("hidden")
+    private boolean hidden;
+
+    @SerializedName("pwls")
+    private int pwls;
+
+    @SerializedName("link_flair_css_class")
+    private Object linkFlairCssClass;
+
+    @SerializedName("downs")
+    private int downs;
+
+    @SerializedName("thumbnail_height")
+    private Object thumbnailHeight;
+
+    @SerializedName("top_awarded_type")
+    private Object topAwardedType;
+
+    @SerializedName("hide_score")
+    private boolean hideScore;
+
+    /**
+     * the fullname identifier of this search result
+     */
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("quarantine")
+    private boolean quarantine;
+
+    @SerializedName("link_flair_text_color")
+    private String linkFlairTextColor;
+
+    @SerializedName("upvote_ratio")
+    private double upvoteRatio;
+
+    @SerializedName("author_flair_background_color")
+    private Object authorFlairBackgroundColor;
+
+    @SerializedName("subreddit_type")
+    private String subredditType;
+
+    @SerializedName("ups")
+    private int ups;
+
+    @SerializedName("total_awards_received")
+    private int totalAwardsReceived;
+
+    @SerializedName("media_embed")
+    private Map<String, Object> mediaEmbed;
+
+    @SerializedName("thumbnail_width")
+    private Object thumbnailWidth;
+
+    @SerializedName("author_flair_template_id")
+    private Object authorFlairTemplateId;
+
+    @SerializedName("is_original_content")
+    private boolean isOriginalContent;
+
+    @SerializedName("user_reports")
+    private List<Object> userReports;
+
+    @SerializedName("secure_media")
+    private Object secureMedia;
+
+    @SerializedName("is_reddit_media_domain")
+    private boolean isRedditMediaDomain;
+
+    @SerializedName("is_meta")
+    private boolean isMeta;
+
+    @SerializedName("category")
+    private String category;
+
+    @SerializedName("secure_media_embed")
+    private Map<String, Object> secureMediaEmbed;
+
+    @SerializedName("link_flair_text")
+    private Object linkFlairText;
+
+    @SerializedName("can_mod_post")
+    private boolean canModPost;
+
+    @SerializedName("score")
+    private int score;
+
+    @SerializedName("approved_by")
+    private String approvedBy;
+
+    @SerializedName("is_created_from_ads_ui")
+    private boolean isCreatedFromAdsUi;
+
+    @SerializedName("author_premium")
+    private boolean authorPremium;
+
+    @SerializedName("thumbnail")
+    private String thumbnail;
+
+    /**
+     * false if not edited, edit date in UTC epoch-seconds otherwise. NOTE: for some old edited comments on reddit.com, this will be set to true instead of edit date.
+     */
+    @SerializedName("edited")
+    private Object edited;
+
+    @SerializedName("author_flair_css_class")
+    private Object authorFlairCssClass;
+
+    @SerializedName("author_flair_richtext")
+    private List<Object> authorFlairRichtext;
+
+    @SerializedName("gildings")
+    private Map<String, Integer> gildings;
+
+    @SerializedName("content_categories")
+    private Object contentCategories;
+
+    @SerializedName("is_self")
+    private boolean isSelf;
+
+    @SerializedName("mod_note")
+    private Object modNote;
+
+    @SerializedName("created")
+    private long created;
+
+    @SerializedName("link_flair_type")
+    private String linkFlairType;
+
+    @SerializedName("wls")
+    private int wls;
+
+    @SerializedName("removed_by_category")
+    private Object removedByCategory;
+
+    @SerializedName("banned_by")
+    private String bannedBy;
+
+    @SerializedName("author_flair_type")
+    private String authorFlairType;
+
+    @SerializedName("domain")
+    private String domain;
+
+    @SerializedName("allow_live_comments")
+    private boolean allowLiveComments;
+
+    @SerializedName("selftext_html")
+    private String selftextHtml;
+
+    @SerializedName("likes")
+    private Object likes;
+
+    @SerializedName("suggested_sort")
+    private Object suggestedSort;
+
+    @SerializedName("banned_at_utc")
+    private Object bannedAtUtc;
+
+    @SerializedName("view_count")
+    private Object viewCount;
+
+    @SerializedName("archived")
+    private boolean archived;
+
+    @SerializedName("no_follow")
+    private boolean noFollow;
+
+    @SerializedName("is_crosspostable")
+    private boolean isCrosspostable;
+
+    @SerializedName("pinned")
+    private boolean pinned;
+
+    @SerializedName("over_18")
+    private boolean over18;
+
+    @SerializedName("all_awardings")
+    private List<Object> allAwardings;
+
+    @SerializedName("awarders")
+    private List<Object> awarders;
+
+    @SerializedName("media_only")
+    private boolean mediaOnly;
+
+    @SerializedName("can_gild")
+    private boolean canGild;
+
+    @SerializedName("spoiler")
+    private boolean spoiler;
+
+    @SerializedName("locked")
+    private boolean locked;
+
+    @SerializedName("author_flair_text")
+    private Object authorFlairText;
+
+    @SerializedName("treatment_tags")
+    private List<Object> treatmentTags;
+
+    @SerializedName("visited")
+    private boolean visited;
+
+    @SerializedName("removed_by")
+    private Object removedBy;
+
+    @SerializedName("num_reports")
+    private Object numReports;
+
+    @SerializedName("distinguished")
+    private Object distinguished;
+
+    @SerializedName("subreddit_id")
+    private String subredditId;
+
+    @SerializedName("author_is_blocked")
+    private boolean authorIsBlocked;
+
+    @SerializedName("mod_reason_by")
+    private Object modReasonBy;
+
+    @SerializedName("removal_reason")
+    private Object removalReason;
+
+    @SerializedName("link_flair_background_color")
+    private String linkFlairBackgroundColor;
+
+    @SerializedName("is_robot_indexable")
+    private boolean isRobotIndexable;
+
+    @SerializedName("report_reasons")
+    private Object reportReasons;
+
+    @SerializedName("author")
+    private String author;
+
+    @SerializedName("discussion_type")
+    private Object discussionType;
+
+    @SerializedName("num_comments")
+    private int numComments;
+
+    @SerializedName("send_replies")
+    private boolean sendReplies;
+
+    @SerializedName("contest_mode")
+    private boolean contestMode;
+
+    @SerializedName("mod_reports")
+    private List<Object> modReports;
+
+    @SerializedName("author_patreon_flair")
+    private boolean authorPatreonFlair;
+
+    @SerializedName("author_flair_text_color")
+    private Object authorFlairTextColor;
+
+    @SerializedName("permalink")
+    private String permalink;
+
+    @SerializedName("stickied")
+    private boolean stickied;
+
+    @SerializedName("url")
+    private String url;
+
+    @SerializedName("subreddit_subscribers")
+    private int subredditSubscribers;
+
+    @SerializedName("created_utc")
+    private double createdUtc;
+
+    @SerializedName("num_crossposts")
+    private int numCrossposts;
+
+    @SerializedName("media")
+    private Object media;
+
+    @SerializedName("is_video")
+    private boolean isVideo;
+}

--- a/src/main/java/masecla/reddit4j/requests/RedditSearchListingEndpointRequest.java
+++ b/src/main/java/masecla/reddit4j/requests/RedditSearchListingEndpointRequest.java
@@ -1,0 +1,79 @@
+package masecla.reddit4j.requests;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import lombok.Getter;
+import lombok.Setter;
+import masecla.reddit4j.client.Reddit4J;
+import masecla.reddit4j.exceptions.AuthenticationException;
+import masecla.reddit4j.objects.Time;
+import masecla.reddit4j.objects.Type;
+import masecla.reddit4j.objects.subreddit.RedditSearch;
+import org.jsoup.Connection;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class RedditSearchListingEndpointRequest extends AbstractListingEndpointRequest<RedditSearch, RedditSearchListingEndpointRequest> {
+    private Time time;
+    private String category;
+    private boolean includeFacets;
+    private String query;
+    private boolean restrictSr;
+    private Type type;
+
+    public RedditSearchListingEndpointRequest(String endpointPath, Reddit4J client) {
+        super(endpointPath, client, RedditSearch.class, RedditSearchListingEndpointRequest.class);
+    }
+
+    @Override
+    public List<RedditSearch> submit() throws IOException, InterruptedException, AuthenticationException {
+        client.ensureConnection();
+        Connection conn = createConnection();
+
+        Connection.Response rsp = conn.execute();
+        JsonArray array = JsonParser.parseString(preprocess(rsp.body()))
+                .getAsJsonObject().getAsJsonObject("data")
+                .getAsJsonArray("children");
+        Gson gson = new Gson();
+
+        List<RedditSearch> result = new ArrayList<>();
+        array.forEach(c -> {
+            RedditSearch value = gson.fromJson(c.getAsJsonObject().getAsJsonObject("data").getAsJsonObject(), clazz);
+            result.add(value);
+        });
+        return result;
+    }
+
+    @Override
+    protected Connection createConnection() {
+        Connection conn = super.createConnection();
+
+        if (time != null) {
+            conn.data("t", time.getValue());
+        }
+        if (category != null && !category.isEmpty()) {
+            if (category.length() > 5) {
+                throw new IllegalArgumentException("Category must be no longer than 5 characters");
+            }
+            conn.data("category", category);
+        }
+        conn.data("include_facets", includeFacets ? "true" : "false");
+        conn.data("restrict_sr", restrictSr ? "true" : "false");
+        if (type != null) {
+            conn.data("type", type.getValue());
+        }
+        if (query == null) {
+            throw new IllegalArgumentException("The query string to look for must be not null");
+        }
+        if (query.length() > 512) {
+            throw new IllegalArgumentException("The query string to look for must be no longer than 512 characters");
+        }
+        conn.data("q", query);
+
+        return conn;
+    }
+}

--- a/src/test/java/mascela/reddit4J/client/Reddit4JTest.java
+++ b/src/test/java/mascela/reddit4J/client/Reddit4JTest.java
@@ -33,4 +33,5 @@ class Reddit4JTest {
     void isValidSubredditNameFalse(String name) {
         assertFalse(Reddit4J.isValidSubredditName(name));
     }
+
 }

--- a/src/test/java/mascela/reddit4J/client/RedditSearchListingEndpointRequestTest.java
+++ b/src/test/java/mascela/reddit4J/client/RedditSearchListingEndpointRequestTest.java
@@ -1,0 +1,47 @@
+package mascela.reddit4J.client;
+
+import masecla.reddit4j.client.Reddit4J;
+import masecla.reddit4j.requests.RedditSearchListingEndpointRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RedditSearchListingEndpointRequestTest {
+
+    private RedditSearchListingEndpointRequest request;
+
+    @BeforeEach
+    void setUp() {
+        Reddit4J client = new TestReddit4J();
+        client.setUserAgent("userAgent");
+        request = new RedditSearchListingEndpointRequest("/search", client);
+    }
+
+    // Test implementation of Reddit4J
+    private static class TestReddit4J extends Reddit4J {
+        @Override
+        public void ensureConnection() {
+            // Do nothing for test
+        }
+    }
+
+    @Test
+    void testSubmit_WithConnection_InvalidCategoryLength() {
+        request.setQuery("valid query");
+        request.setCategory("toolong");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> request.submit());
+        assertEquals("Category must be no longer than 5 characters", exception.getMessage());
+    }
+
+    @Test
+    void testSubmit_WithConnection_NullQuery() {
+        request.setQuery(null);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> request.submit());
+        assertEquals("The query string to look for must be not null", exception.getMessage());
+    }
+}
+
+


### PR DESCRIPTION
Hello maintainers, 
I have added new functionality to this client library to support calling the /search API. 

Changes made:

- Added a new method getSearchResult() in the Reddit4J class
- Implemented request building for the /search endpoint by overriding also the createConnection with all possible params
- Added response parsing for search results with class RedditSearch
- Added Type enum
- Update Sorting enum
- Added unit tests for the new submit() method of RedditSearchListingEndpointRequest

Please review the changes and let me know if you need any further information or modifications. 
Thank you for considering this contribution!