### PR TITLE
Fix Jitpack build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
+            <version>5.13.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Jitpack build became broken after the JUnit version 6.0.0-M1 was released on Jun 27, 2025. JUnit 6 built with Java 17 while Jitpack uses Java 8 by default.